### PR TITLE
Token-guarded remote control: /ac/* shortcut endpoints + /panel UI

### DIFF
--- a/server.py
+++ b/server.py
@@ -22,6 +22,7 @@ Usage:
 
 import asyncio
 import json
+import os
 import sys
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -32,7 +33,7 @@ _SRC = Path(__file__).parent / "src"
 if _SRC.exists() and str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import HTMLResponse, PlainTextResponse
 from fastapi.staticfiles import StaticFiles
 
@@ -66,6 +67,15 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(title="Switcher AC Cloud Control", lifespan=lifespan)
+
+# Optional shared-secret guard for state-changing endpoints. When CONTROL_TOKEN
+# is set (in .env), callers must pass ?key=<token>; otherwise requests are open.
+CONTROL_TOKEN = os.environ.get("CONTROL_TOKEN", "")
+
+
+def _require_token(key: str) -> None:
+    if CONTROL_TOKEN and key != CONTROL_TOKEN:
+        raise HTTPException(status_code=403, detail="forbidden")
 
 
 @app.middleware("http")
@@ -110,8 +120,7 @@ def _clamp_num(v, lo, hi, default):
         return default
 
 
-@app.post("/api/config")
-async def api_config(patch: Dict[str, Any]):
+def _apply_config_patch(patch: Dict[str, Any]) -> Dict[str, Any]:
     """Merge a partial, validated config patch into the stored state.
 
     Accepts any subset of: mode, too_hot_temp, too_cold_temp, cool_temp,
@@ -154,6 +163,12 @@ async def api_config(patch: Dict[str, Any]):
     return d
 
 
+@app.post("/api/config")
+async def api_config(patch: Dict[str, Any]):
+    """Merge a partial config patch (used by the dashboard and other clients)."""
+    return _apply_config_patch(patch)
+
+
 def _now_iso() -> str:
     # Local import keeps datetime out of the module top (and mirrors auto_cloud's
     # naive-local timestamps used everywhere else in the app).
@@ -183,8 +198,9 @@ async def live_temp():
 # ---------------------------------------------------------------------------
 
 @app.get("/control/on")
-async def turn_on(temp: int = 24, fan: str = "medium", mode: str = "cool"):
-    """Turn AC on. Optional: ?temp=22&fan=high&mode=cool"""
+async def turn_on(temp: int = 24, fan: str = "medium", mode: str = "cool", key: str = ""):
+    """Turn AC on. Optional: ?temp=22&fan=high&mode=cool (&key=<token> if set)"""
+    _require_token(key)
     success = await cloud_control("on", temp=temp, fan=fan, mode=mode)
     if success:
         _patch_data({"is_on": True, "ac_temp": temp})
@@ -193,12 +209,61 @@ async def turn_on(temp: int = 24, fan: str = "medium", mode: str = "cool"):
 
 
 @app.get("/control/off")
-async def turn_off():
+async def turn_off(key: str = ""):
+    _require_token(key)
     success = await cloud_control("off")
     if success:
         _patch_data({"is_on": False})
         return {"status": "ok", "action": "off"}
     return {"status": "error", "message": "cloud command failed"}
+
+
+# ---------------------------------------------------------------------------
+# Shortcut endpoints — combine a mode switch with a control action so a manual
+# on/off "sticks" (in manual mode the loop only observes, never overrides).
+# Token-guarded, GET-friendly for Apple Shortcuts.
+# ---------------------------------------------------------------------------
+
+@app.get("/ac/on")
+async def ac_on(key: str = "", temp: int = 25, fan: str = "low", mode: str = "cool"):
+    """Switch to manual + turn AC on (default 25°C). e.g. /ac/on?key=..&temp=22"""
+    _require_token(key)
+    _apply_config_patch({"mode": "manual", "cool_temp": temp})
+    success = await cloud_control("on", temp=temp, fan=fan, mode=mode)
+    if success:
+        _patch_data({"is_on": True, "ac_temp": temp})
+        return {"status": "ok", "action": "on", "mode": "manual", "temp": temp}
+    return {"status": "error", "message": "cloud command failed"}
+
+
+@app.get("/ac/off")
+async def ac_off(key: str = ""):
+    """Switch to manual + turn AC off."""
+    _require_token(key)
+    _apply_config_patch({"mode": "manual"})
+    success = await cloud_control("off")
+    if success:
+        _patch_data({"is_on": False})
+        return {"status": "ok", "action": "off", "mode": "manual"}
+    return {"status": "error", "message": "cloud command failed"}
+
+
+@app.get("/ac/cycle")
+async def ac_cycle(key: str = "", on: float = 15, off: float = 10, temp: int = 26):
+    """Switch to cycle mode with defaults (15 on / 10 off / 26°C), all
+    overridable: /ac/cycle?key=..&on=20&off=8&temp=24. The loop then drives the
+    AC on/off on this rhythm (re-anchored to ON now)."""
+    _require_token(key)
+    d = _apply_config_patch(
+        {"mode": "cycle", "cycle_on_min": on, "cycle_off_min": off, "cool_temp": temp}
+    )
+    return {
+        "status": "ok",
+        "mode": d.get("mode"),
+        "cycle_on_min": d.get("cycle_on_min"),
+        "cycle_off_min": d.get("cycle_off_min"),
+        "cool_temp": d.get("cool_temp"),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -219,6 +284,17 @@ async def read_root():
     if index.exists():
         return index.read_text()
     return "<h1>Switcher AC Control</h1><p><a href='/control/on'>ON</a> | <a href='/control/off'>OFF</a></p>"
+
+
+@app.get("/panel", response_class=HTMLResponse)
+async def control_panel():
+    """Lightweight self-contained mobile control panel with On/Off + cycle
+    presets. Reads the token from its own URL (?key=...) so the secret lives in
+    the bookmark, not in publicly-served HTML."""
+    panel = Path("webapp/panel.html")
+    if panel.exists():
+        return panel.read_text()
+    return HTMLResponse("<h1>panel.html missing</h1>", status_code=404)
 
 
 @app.get("/data")

--- a/server.py
+++ b/server.py
@@ -26,7 +26,7 @@ import os
 import sys
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 # aioswitcher lives under ./src (mirrors the PYTHONPATH=src the CLIs use).
 _SRC = Path(__file__).parent / "src"
@@ -263,6 +263,40 @@ async def ac_cycle(key: str = "", on: float = 15, off: float = 10, temp: int = 2
         "cycle_on_min": d.get("cycle_on_min"),
         "cycle_off_min": d.get("cycle_off_min"),
         "cool_temp": d.get("cool_temp"),
+    }
+
+
+@app.get("/ac/config")
+async def ac_config_get(
+    key: str = "",
+    mode: Optional[str] = None,
+    cool_temp: Optional[int] = None,
+    cycle_on_min: Optional[float] = None,
+    cycle_off_min: Optional[float] = None,
+    poll_interval: Optional[int] = None,
+):
+    """Granular config for the web panel (token-guarded, GET). Applies any
+    provided field via the shared patch. Does not toggle power — use /ac/on|off
+    for that (or re-call /ac/on to apply a new temp immediately in manual mode)."""
+    _require_token(key)
+    patch: Dict[str, Any] = {}
+    for name, val in (
+        ("mode", mode),
+        ("cool_temp", cool_temp),
+        ("cycle_on_min", cycle_on_min),
+        ("cycle_off_min", cycle_off_min),
+        ("poll_interval", poll_interval),
+    ):
+        if val is not None:
+            patch[name] = val
+    d = _apply_config_patch(patch)
+    return {
+        "status": "ok",
+        "mode": d.get("mode"),
+        "cool_temp": d.get("cool_temp"),
+        "cycle_on_min": d.get("cycle_on_min"),
+        "cycle_off_min": d.get("cycle_off_min"),
+        "is_on": d.get("is_on"),
     }
 
 

--- a/server.py
+++ b/server.py
@@ -320,6 +320,17 @@ async def read_root():
     return "<h1>Switcher AC Control</h1><p><a href='/control/on'>ON</a> | <a href='/control/off'>OFF</a></p>"
 
 
+@app.get("/panel/version")
+async def panel_version():
+    """Build stamp (panel.html mtime) so an open panel can auto-reload itself
+    when a new version is deployed — no need to re-add the home-screen icon."""
+    try:
+        v = int(Path("webapp/panel.html").stat().st_mtime)
+    except OSError:
+        v = 0
+    return {"v": v}
+
+
 @app.get("/panel", response_class=HTMLResponse)
 async def control_panel():
     """Lightweight self-contained mobile control panel with On/Off + cycle

--- a/webapp/panel.html
+++ b/webapp/panel.html
@@ -156,6 +156,7 @@
   </div>
 
   <div class="foot" id="foot">—</div>
+  <div class="foot" id="ver" style="margin-top:2px; color:#3f4a6b;">build —</div>
 </div>
 
 <div id="toast"></div>
@@ -172,6 +173,11 @@
   async function checkVersion() {
     try {
       const { v } = await (await fetch('/panel/version', { cache: 'no-store' })).json();
+      if (v) {
+        const d = new Date(v * 1000), p = n => String(n).padStart(2, '0');
+        document.getElementById('ver').textContent =
+          `build ${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}`;
+      }
       if (BOOT_V === null) BOOT_V = v;
       else if (v && v !== BOOT_V) location.reload();
     } catch (e) { /* offline — ignore */ }

--- a/webapp/panel.html
+++ b/webapp/panel.html
@@ -14,35 +14,61 @@
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
     background: radial-gradient(1200px 600px at 50% -10%, #16224a 0%, #0b1020 55%, #070b16 100%);
     color: #e8ecf6; display: flex; flex-direction: column; align-items: center;
-    padding: max(24px, env(safe-area-inset-top)) 18px calc(24px + env(safe-area-inset-bottom));
+    padding: max(22px, env(safe-area-inset-top)) 16px calc(28px + env(safe-area-inset-bottom));
   }
   .wrap { width: 100%; max-width: 460px; }
-  header { text-align: center; margin: 8px 0 22px; }
+  header { text-align: center; margin: 6px 0 18px; }
   h1 { font-size: 15px; letter-spacing: .14em; text-transform: uppercase; color: #8ea0c8; font-weight: 600; margin: 0; }
   .card {
     background: linear-gradient(180deg, rgba(255,255,255,.055), rgba(255,255,255,.02));
-    border: 1px solid rgba(255,255,255,.08); border-radius: 22px; padding: 24px;
-    box-shadow: 0 12px 40px rgba(0,0,0,.4); margin-bottom: 18px;
+    border: 1px solid rgba(255,255,255,.08); border-radius: 22px; padding: 22px;
+    box-shadow: 0 12px 40px rgba(0,0,0,.4); margin-bottom: 16px;
   }
   .temp { text-align: center; }
-  .temp .val { font-size: 66px; font-weight: 800; line-height: 1; letter-spacing: -.02em; }
-  .temp .val small { font-size: 26px; font-weight: 600; color: #8ea0c8; }
+  .temp .val { font-size: 60px; font-weight: 800; line-height: 1; letter-spacing: -.02em; }
+  .temp .val small { font-size: 24px; font-weight: 600; color: #8ea0c8; }
+  .temp .lbl { font-size: 12px; letter-spacing: .1em; text-transform: uppercase; color: #6f80a6; margin-bottom: 8px; }
   .pills { display: flex; gap: 8px; justify-content: center; margin-top: 14px; flex-wrap: wrap; }
   .pill { font-size: 12.5px; font-weight: 600; padding: 6px 12px; border-radius: 999px; background: rgba(255,255,255,.07); color: #b9c4de; }
   .pill.on  { background: rgba(52,199,120,.18); color: #7ff0b0; }
   .pill.off { background: rgba(255,99,99,.16);  color: #ff9d9d; }
+  .section-label { font-size: 12px; letter-spacing: .12em; text-transform: uppercase; color: #6f80a6; margin: 2px 2px 9px; }
+
+  /* stepper */
+  .stepper { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+  .stepper.small { padding: 4px 0; }
+  .stepper .name { font-size: 15px; font-weight: 600; color: #cdd7ee; }
+  .stepper .name .u { font-size: 12px; color: #7f8db0; font-weight: 500; }
+  .stepbox { display: flex; align-items: center; gap: 14px; }
+  .rnd {
+    width: 46px; height: 46px; border-radius: 50%; border: 1px solid rgba(255,255,255,.12);
+    background: rgba(255,255,255,.06); color: #eef2fb; font-size: 24px; font-weight: 600;
+    display: flex; align-items: center; justify-content: center; cursor: pointer; transition: transform .06s, filter .15s;
+  }
+  .rnd:active { transform: scale(.9); filter: brightness(1.3); }
+  .stepval { font-size: 30px; font-weight: 800; min-width: 66px; text-align: center; }
+  .stepval small { font-size: 15px; color: #8ea0c8; font-weight: 600; }
+
+  /* segmented */
+  .seg { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 6px; background: rgba(255,255,255,.04); padding: 5px; border-radius: 15px; border: 1px solid rgba(255,255,255,.07); }
+  .seg button {
+    appearance: none; border: 0; background: transparent; color: #a7b3d4; font-size: 14px; font-weight: 600;
+    padding: 11px 6px; border-radius: 11px; cursor: pointer; transition: background .15s, color .15s;
+  }
+  .seg button.active { background: linear-gradient(180deg, rgba(90,140,255,.4), rgba(90,140,255,.22)); color: #fff; box-shadow: 0 4px 14px rgba(60,110,255,.25); }
+
   .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
   button.act {
     appearance: none; border: 1px solid rgba(255,255,255,.10); border-radius: 16px;
-    padding: 18px 12px; font-size: 16px; font-weight: 700; color: #eef2fb;
+    padding: 16px 12px; font-size: 16px; font-weight: 700; color: #eef2fb;
     background: rgba(255,255,255,.05); cursor: pointer; transition: transform .06s, filter .15s;
     display: flex; flex-direction: column; align-items: center; gap: 3px;
   }
-  button.act .sub { font-size: 11.5px; font-weight: 500; color: #93a1c4; letter-spacing: .01em; }
+  button.act .sub { font-size: 11.5px; font-weight: 500; color: #93a1c4; }
   button.act:active { transform: scale(.96); filter: brightness(1.15); }
   button.on  { background: linear-gradient(180deg, rgba(52,199,120,.28), rgba(52,199,120,.14)); border-color: rgba(52,199,120,.35); }
   button.off { background: linear-gradient(180deg, rgba(255,99,99,.26), rgba(255,99,99,.12)); border-color: rgba(255,99,99,.32); }
-  .section-label { font-size: 12px; letter-spacing: .12em; text-transform: uppercase; color: #6f80a6; margin: 4px 2px 10px; }
+  .hidden { display: none !important; }
   #toast {
     position: fixed; left: 50%; bottom: calc(26px + env(safe-area-inset-bottom)); transform: translateX(-50%) translateY(20px);
     padding: 12px 18px; border-radius: 12px; font-size: 14px; font-weight: 600;
@@ -51,8 +77,9 @@
   }
   #toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
   #toast.err { background: #3a1620; border-color: rgba(255,99,99,.4); }
-  .nokey { text-align: center; font-size: 13px; color: #ffb27a; margin-top: -6px; margin-bottom: 14px; }
-  .foot { text-align: center; font-size: 11.5px; color: #56638a; margin-top: 6px; }
+  .nokey { text-align: center; font-size: 13px; color: #ffb27a; margin: -4px 0 14px; }
+  .foot { text-align: center; font-size: 11.5px; color: #56638a; margin-top: 4px; }
+  .divider { height: 1px; background: rgba(255,255,255,.07); margin: 16px 0; }
 </style>
 </head>
 <body>
@@ -61,27 +88,71 @@
 
   <div class="card">
     <div class="temp">
+      <div class="lbl">Room temperature</div>
       <div class="val" id="temp">--<small>°</small></div>
       <div class="pills">
         <span class="pill" id="power">—</span>
-        <span class="pill" id="mode">—</span>
-        <span class="pill" id="set">—</span>
+        <span class="pill" id="modepill">—</span>
       </div>
     </div>
   </div>
 
-  <div id="nokey" class="nokey" hidden>⚠︎ No key in URL — controls disabled. Open with <code>?key=…</code></div>
+  <div id="nokey" class="nokey hidden">⚠︎ No key in URL — controls disabled. Open with <code>?key=…</code></div>
 
-  <div class="section-label">Power</div>
-  <div class="grid" style="margin-bottom:18px">
-    <button class="act on"  onclick="go('/ac/on','On')"><span>On</span><span class="sub">manual · 25°</span></button>
-    <button class="act off" onclick="go('/ac/off','Off')"><span>Off</span><span class="sub">manual</span></button>
+  <!-- target temperature -->
+  <div class="card">
+    <div class="stepper">
+      <div class="name">Target temp</div>
+      <div class="stepbox">
+        <div class="rnd" onclick="bumpTemp(-1)">−</div>
+        <div class="stepval"><span id="settemp">--</span><small>°</small></div>
+        <div class="rnd" onclick="bumpTemp(1)">+</div>
+      </div>
+    </div>
   </div>
 
-  <div class="section-label">Cycle presets</div>
+  <!-- mode -->
+  <div class="section-label">Mode</div>
+  <div class="seg" id="seg">
+    <button data-mode="manual"     onclick="setMode('manual')">Manual</button>
+    <button data-mode="thermostat" onclick="setMode('thermostat')">Thermostat</button>
+    <button data-mode="cycle"      onclick="setMode('cycle')">Cycle</button>
+  </div>
+
+  <!-- power -->
+  <div class="section-label" style="margin-top:16px">Power</div>
   <div class="grid">
-    <button class="act" onclick="go('/ac/cycle?on=6&off=15&temp=25','Night')"><span>🌙 Night</span><span class="sub">25° · 6 on / 15 off</span></button>
-    <button class="act" onclick="go('/ac/cycle?on=15&off=10&temp=24','Noon')"><span>☀️ Noon</span><span class="sub">24° · 15 on / 10 off</span></button>
+    <button class="act on"  onclick="power('on')"><span>On</span><span class="sub" id="onsub">manual · 25°</span></button>
+    <button class="act off" onclick="power('off')"><span>Off</span><span class="sub">manual</span></button>
+  </div>
+
+  <!-- cycle params (only in cycle mode) -->
+  <div class="card hidden" id="cyclecard" style="margin-top:16px">
+    <div class="section-label" style="margin:0 0 12px">Cycle timing</div>
+    <div class="stepper small">
+      <div class="name">On <span class="u">minutes</span></div>
+      <div class="stepbox">
+        <div class="rnd" onclick="bumpCycle('on',-1)">−</div>
+        <div class="stepval"><span id="onmin">--</span></div>
+        <div class="rnd" onclick="bumpCycle('on',1)">+</div>
+      </div>
+    </div>
+    <div class="divider"></div>
+    <div class="stepper small">
+      <div class="name">Off <span class="u">minutes</span></div>
+      <div class="stepbox">
+        <div class="rnd" onclick="bumpCycle('off',-1)">−</div>
+        <div class="stepval"><span id="offmin">--</span></div>
+        <div class="rnd" onclick="bumpCycle('off',1)">+</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- presets -->
+  <div class="section-label" style="margin-top:16px">Cycle presets</div>
+  <div class="grid">
+    <button class="act" onclick="preset('/ac/cycle?on=6&off=15&temp=25','Night')"><span>🌙 Night</span><span class="sub">25° · 6 on / 15 off</span></button>
+    <button class="act" onclick="preset('/ac/cycle?on=15&off=10&temp=24','Noon')"><span>☀️ Noon</span><span class="sub">24° · 15 on / 10 off</span></button>
   </div>
 
   <div class="foot" id="foot">—</div>
@@ -91,7 +162,9 @@
 
 <script>
   const KEY = new URLSearchParams(location.search).get('key') || '';
-  if (!KEY) document.getElementById('nokey').hidden = false;
+  if (!KEY) document.getElementById('nokey').classList.remove('hidden');
+  const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
+  let state = { mode: null, is_on: false, cool_temp: 24, cycle_on_min: 15, cycle_off_min: 10, temperature: null };
 
   function toast(msg, err) {
     const t = document.getElementById('toast');
@@ -99,32 +172,69 @@
     clearTimeout(t._h); t._h = setTimeout(() => t.className = '', 1900);
   }
 
-  async function go(path, label) {
-    if (!KEY) { toast('No key — open panel with ?key=…', true); return; }
+  // Fire a token-guarded GET; `path` may already include query params.
+  async function call(path, label) {
+    if (!KEY) { toast('No key — open panel with ?key=…', true); return null; }
     const sep = path.includes('?') ? '&' : '?';
     try {
       const r = await fetch(path + sep + 'key=' + encodeURIComponent(KEY));
-      if (r.status === 403) { toast('Wrong key — forbidden', true); return; }
+      if (r.status === 403) { toast('Wrong key — forbidden', true); return null; }
       const j = await r.json();
-      if (j.status === 'ok') { toast('✓ ' + label); refresh(); }
-      else toast(label + ' failed: ' + (j.message || 'error'), true);
-    } catch (e) { toast('Network error', true); }
+      if (j.status === 'ok') { if (label) toast('✓ ' + label); refresh(); return j; }
+      toast((label || 'action') + ' failed', true); return null;
+    } catch (e) { toast('Network error', true); return null; }
+  }
+
+  const power  = (which) => call('/ac/' + which, which === 'on' ? 'On' : 'Off');
+  const preset = (path, label) => call(path, label);
+  const setMode = (m) => call('/ac/config?mode=' + m, m[0].toUpperCase() + m.slice(1));
+
+  function bumpTemp(delta) {
+    const t = clamp((state.cool_temp || 24) + delta, 16, 30);
+    // In manual + on, re-issue /ac/on so the unit changes immediately;
+    // otherwise just store the target (applies per mode).
+    if (state.mode === 'manual' && state.is_on) call('/ac/on?temp=' + t, 'Set ' + t + '°');
+    else call('/ac/config?cool_temp=' + t, 'Set ' + t + '°');
+  }
+
+  function bumpCycle(which, delta) {
+    if (which === 'on') {
+      const v = clamp((state.cycle_on_min || 15) + delta, 1, 240);
+      call('/ac/config?cycle_on_min=' + v, 'On ' + v + 'm');
+    } else {
+      const v = clamp((state.cycle_off_min || 10) + delta, 1, 240);
+      call('/ac/config?cycle_off_min=' + v, 'Off ' + v + 'm');
+    }
+  }
+
+  function render() {
+    const s = state;
+    document.getElementById('temp').innerHTML =
+      (s.temperature != null ? Number(s.temperature).toFixed(1) : '--') + '<small>°</small>';
+    const p = document.getElementById('power');
+    p.textContent = s.is_on ? 'ON' : 'OFF'; p.className = 'pill ' + (s.is_on ? 'on' : 'off');
+    document.getElementById('modepill').textContent = s.mode || '—';
+    document.getElementById('settemp').textContent = s.cool_temp ?? '--';
+    document.getElementById('onsub').textContent = 'manual · ' + (s.cool_temp ?? 25) + '°';
+    // mode segmented highlight
+    document.querySelectorAll('#seg button').forEach(b =>
+      b.classList.toggle('active', b.dataset.mode === s.mode));
+    // cycle card visibility + values
+    const cyc = s.mode === 'cycle';
+    document.getElementById('cyclecard').classList.toggle('hidden', !cyc);
+    document.getElementById('onmin').textContent = s.cycle_on_min ?? '--';
+    document.getElementById('offmin').textContent = s.cycle_off_min ?? '--';
+    let foot = cyc
+      ? 'cycle ' + s.cycle_on_min + ' on / ' + s.cycle_off_min + ' off @ ' + s.cool_temp + '°'
+      : (s.last_poll ? 'last poll ' + s.last_poll.replace('T', ' ').slice(0, 19) : '—');
+    document.getElementById('foot').textContent = foot;
   }
 
   async function refresh() {
     try {
       const s = await (await fetch('/api/state')).json();
-      document.getElementById('temp').innerHTML =
-        (s.temperature != null ? Number(s.temperature).toFixed(1) : '--') + '<small>°</small>';
-      const on = s.is_on;
-      const p = document.getElementById('power');
-      p.textContent = on ? 'ON' : 'OFF'; p.className = 'pill ' + (on ? 'on' : 'off');
-      document.getElementById('mode').textContent = 'mode: ' + (s.mode || '—');
-      document.getElementById('set').textContent = 'set ' + (s.ac_temp ?? '—') + '°';
-      let foot = '';
-      if (s.mode === 'cycle') foot = 'cycle ' + s.cycle_on_min + ' on / ' + s.cycle_off_min + ' off @ ' + s.cool_temp + '°';
-      else foot = 'last poll ' + (s.last_poll ? s.last_poll.replace('T', ' ').slice(0, 19) : '—');
-      document.getElementById('foot').textContent = foot;
+      state = Object.assign(state, s);
+      render();
     } catch (e) { /* keep last */ }
   }
 

--- a/webapp/panel.html
+++ b/webapp/panel.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+<meta name="apple-mobile-web-app-capable" content="yes" />
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+<title>AC Control</title>
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
+  body {
+    margin: 0; min-height: 100dvh;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: radial-gradient(1200px 600px at 50% -10%, #16224a 0%, #0b1020 55%, #070b16 100%);
+    color: #e8ecf6; display: flex; flex-direction: column; align-items: center;
+    padding: max(24px, env(safe-area-inset-top)) 18px calc(24px + env(safe-area-inset-bottom));
+  }
+  .wrap { width: 100%; max-width: 460px; }
+  header { text-align: center; margin: 8px 0 22px; }
+  h1 { font-size: 15px; letter-spacing: .14em; text-transform: uppercase; color: #8ea0c8; font-weight: 600; margin: 0; }
+  .card {
+    background: linear-gradient(180deg, rgba(255,255,255,.055), rgba(255,255,255,.02));
+    border: 1px solid rgba(255,255,255,.08); border-radius: 22px; padding: 24px;
+    box-shadow: 0 12px 40px rgba(0,0,0,.4); margin-bottom: 18px;
+  }
+  .temp { text-align: center; }
+  .temp .val { font-size: 66px; font-weight: 800; line-height: 1; letter-spacing: -.02em; }
+  .temp .val small { font-size: 26px; font-weight: 600; color: #8ea0c8; }
+  .pills { display: flex; gap: 8px; justify-content: center; margin-top: 14px; flex-wrap: wrap; }
+  .pill { font-size: 12.5px; font-weight: 600; padding: 6px 12px; border-radius: 999px; background: rgba(255,255,255,.07); color: #b9c4de; }
+  .pill.on  { background: rgba(52,199,120,.18); color: #7ff0b0; }
+  .pill.off { background: rgba(255,99,99,.16);  color: #ff9d9d; }
+  .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+  button.act {
+    appearance: none; border: 1px solid rgba(255,255,255,.10); border-radius: 16px;
+    padding: 18px 12px; font-size: 16px; font-weight: 700; color: #eef2fb;
+    background: rgba(255,255,255,.05); cursor: pointer; transition: transform .06s, filter .15s;
+    display: flex; flex-direction: column; align-items: center; gap: 3px;
+  }
+  button.act .sub { font-size: 11.5px; font-weight: 500; color: #93a1c4; letter-spacing: .01em; }
+  button.act:active { transform: scale(.96); filter: brightness(1.15); }
+  button.on  { background: linear-gradient(180deg, rgba(52,199,120,.28), rgba(52,199,120,.14)); border-color: rgba(52,199,120,.35); }
+  button.off { background: linear-gradient(180deg, rgba(255,99,99,.26), rgba(255,99,99,.12)); border-color: rgba(255,99,99,.32); }
+  .section-label { font-size: 12px; letter-spacing: .12em; text-transform: uppercase; color: #6f80a6; margin: 4px 2px 10px; }
+  #toast {
+    position: fixed; left: 50%; bottom: calc(26px + env(safe-area-inset-bottom)); transform: translateX(-50%) translateY(20px);
+    padding: 12px 18px; border-radius: 12px; font-size: 14px; font-weight: 600;
+    opacity: 0; pointer-events: none; transition: opacity .2s, transform .2s; border: 1px solid rgba(255,255,255,.12);
+    background: #17203f; box-shadow: 0 8px 30px rgba(0,0,0,.5); max-width: 90vw; text-align: center;
+  }
+  #toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
+  #toast.err { background: #3a1620; border-color: rgba(255,99,99,.4); }
+  .nokey { text-align: center; font-size: 13px; color: #ffb27a; margin-top: -6px; margin-bottom: 14px; }
+  .foot { text-align: center; font-size: 11.5px; color: #56638a; margin-top: 6px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header><h1>AC Control</h1></header>
+
+  <div class="card">
+    <div class="temp">
+      <div class="val" id="temp">--<small>°</small></div>
+      <div class="pills">
+        <span class="pill" id="power">—</span>
+        <span class="pill" id="mode">—</span>
+        <span class="pill" id="set">—</span>
+      </div>
+    </div>
+  </div>
+
+  <div id="nokey" class="nokey" hidden>⚠︎ No key in URL — controls disabled. Open with <code>?key=…</code></div>
+
+  <div class="section-label">Power</div>
+  <div class="grid" style="margin-bottom:18px">
+    <button class="act on"  onclick="go('/ac/on','On')"><span>On</span><span class="sub">manual · 25°</span></button>
+    <button class="act off" onclick="go('/ac/off','Off')"><span>Off</span><span class="sub">manual</span></button>
+  </div>
+
+  <div class="section-label">Cycle presets</div>
+  <div class="grid">
+    <button class="act" onclick="go('/ac/cycle?on=6&off=15&temp=25','Night')"><span>🌙 Night</span><span class="sub">25° · 6 on / 15 off</span></button>
+    <button class="act" onclick="go('/ac/cycle?on=15&off=10&temp=24','Noon')"><span>☀️ Noon</span><span class="sub">24° · 15 on / 10 off</span></button>
+  </div>
+
+  <div class="foot" id="foot">—</div>
+</div>
+
+<div id="toast"></div>
+
+<script>
+  const KEY = new URLSearchParams(location.search).get('key') || '';
+  if (!KEY) document.getElementById('nokey').hidden = false;
+
+  function toast(msg, err) {
+    const t = document.getElementById('toast');
+    t.textContent = msg; t.className = 'show' + (err ? ' err' : '');
+    clearTimeout(t._h); t._h = setTimeout(() => t.className = '', 1900);
+  }
+
+  async function go(path, label) {
+    if (!KEY) { toast('No key — open panel with ?key=…', true); return; }
+    const sep = path.includes('?') ? '&' : '?';
+    try {
+      const r = await fetch(path + sep + 'key=' + encodeURIComponent(KEY));
+      if (r.status === 403) { toast('Wrong key — forbidden', true); return; }
+      const j = await r.json();
+      if (j.status === 'ok') { toast('✓ ' + label); refresh(); }
+      else toast(label + ' failed: ' + (j.message || 'error'), true);
+    } catch (e) { toast('Network error', true); }
+  }
+
+  async function refresh() {
+    try {
+      const s = await (await fetch('/api/state')).json();
+      document.getElementById('temp').innerHTML =
+        (s.temperature != null ? Number(s.temperature).toFixed(1) : '--') + '<small>°</small>';
+      const on = s.is_on;
+      const p = document.getElementById('power');
+      p.textContent = on ? 'ON' : 'OFF'; p.className = 'pill ' + (on ? 'on' : 'off');
+      document.getElementById('mode').textContent = 'mode: ' + (s.mode || '—');
+      document.getElementById('set').textContent = 'set ' + (s.ac_temp ?? '—') + '°';
+      let foot = '';
+      if (s.mode === 'cycle') foot = 'cycle ' + s.cycle_on_min + ' on / ' + s.cycle_off_min + ' off @ ' + s.cool_temp + '°';
+      else foot = 'last poll ' + (s.last_poll ? s.last_poll.replace('T', ' ').slice(0, 19) : '—');
+      document.getElementById('foot').textContent = foot;
+    } catch (e) { /* keep last */ }
+  }
+
+  refresh();
+  setInterval(refresh, 5000);
+</script>
+</body>
+</html>

--- a/webapp/panel.html
+++ b/webapp/panel.html
@@ -166,6 +166,17 @@
   const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
   let state = { mode: null, is_on: false, cool_temp: 24, cycle_on_min: 15, cycle_off_min: 10, temperature: null };
 
+  // Auto-update: reload the page when a newer panel is deployed, so the
+  // home-screen web app never gets stuck on an old version.
+  let BOOT_V = null;
+  async function checkVersion() {
+    try {
+      const { v } = await (await fetch('/panel/version', { cache: 'no-store' })).json();
+      if (BOOT_V === null) BOOT_V = v;
+      else if (v && v !== BOOT_V) location.reload();
+    } catch (e) { /* offline — ignore */ }
+  }
+
   function toast(msg, err) {
     const t = document.getElementById('toast');
     t.textContent = msg; t.className = 'show' + (err ? ' err' : '');
@@ -239,7 +250,11 @@
   }
 
   refresh();
+  checkVersion();
   setInterval(refresh, 5000);
+  setInterval(checkVersion, 6000);
+  // Also re-check the moment the web app comes back to the foreground.
+  document.addEventListener('visibilitychange', () => { if (!document.hidden) { refresh(); checkVersion(); } });
 </script>
 </body>
 </html>


### PR DESCRIPTION
Adds remote/voice control for the AC daemon, guarded by a shared secret.

## What's in it
- **Token auth** (`CONTROL_TOKEN` from `.env`) on state-changing endpoints via `?key=<token>`. Reads (`/temp`, `/api/state`, dashboard) stay open.
- **Shortcut endpoints** (GET, Apple Shortcuts / one-shot voice):
  - `/ac/on` → mode→manual + on (default 25°, so manual control *sticks*; the loop only observes in manual)
  - `/ac/off` → mode→manual + off
  - `/ac/cycle` → mode→cycle with defaults 15/10/26, overridable `?on&off&temp`
- **Refactor**: config write extracted into `_apply_config_patch()`, shared by `/api/config` and `/ac/*`.
- **Mobile control panel** at `/panel` — self-contained (no CDNs), On/Off + Night/Noon presets, live temp, 5s refresh. Token read from the panel URL (`?key=`), never baked into served HTML; buttons disabled without it.

## Security
- No token in tracked files; `.env` gitignored.
- Same token gates shortcuts + panel, so one rotation kills both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)